### PR TITLE
libchdb binding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.7"
     - name: Fetch library
       run: |
           sudo apt update && sudo apt install -y binutils
-          python3 -m pip install chdb
-          find /opt/hostedtoolcache/Python -name _chdb*.so
-          sudo mv /opt/hostedtoolcache/Python/3.7.16/x64/lib/python3.7/site-packages/chdb/_chdb.cpython-37m-x86_64-linux-gnu.so /usr/lib/libchdb.so
-          sudo strip /usr/lib/libchdb.so
-          sudo zip /tmp/libchdb.x86_64-linux-gnu.zip /usr/lib/libchdb.so
+          sudo wget https://github.com/metrico/libchdb/releases/download/0.7.0/libchdb_amd64.zip
+          sudo unzip libchdb_amd64.zip
+          sudo mv libchdb.so /usr/lib/libchdb.so
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
@@ -41,7 +35,7 @@ jobs:
       with:
         release_config: |
             chdbgo
-            /tmp/libchdb.x86_64-linux-gnu.zip
+            libchdb_amd64.zip
         tag_name: ${{ env.VERSION }}
         release_name: chdbgo_${{ env.VERSION }}
         draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Fetch library
       run: |
-          sudo wget https://github.com/metrico/libchdb/releases/download/0.7.0/libchdb_amd64.zip
+          sudo wget https://github.com/metrico/libchdb/releases/latest/download/libchdb_amd64.zip
           sudo unzip libchdb_amd64.zip
           sudo mv libchdb.so /usr/lib/libchdb.so
     - name: Set up Go
@@ -22,7 +22,9 @@ jobs:
     - name: Build
       run: |
           go mod tidy
-          go build -o chdbgo main.go        
+          go build -o chdbgo main.go  
+    - name: Test
+      run: ./chdbgo
     - name: Get Version
       run: |
         echo "VERSION=${{  github.ref_name }}" >> $GITHUB_ENV
@@ -34,7 +36,6 @@ jobs:
       with:
         release_config: |
             chdbgo
-            libchdb_amd64.zip
         tag_name: ${{ env.VERSION }}
         release_name: chdbgo_${{ env.VERSION }}
         draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Fetch library
       run: |
-          sudo apt update && sudo apt install -y binutils
           sudo wget https://github.com/metrico/libchdb/releases/download/0.7.0/libchdb_amd64.zip
           sudo unzip libchdb_amd64.zip
           sudo mv libchdb.so /usr/lib/libchdb.so

--- a/chdb/chdb.go
+++ b/chdb/chdb.go
@@ -1,7 +1,6 @@
 package chdb
 
 /*
-#cgo pkg-config: python3
 #cgo CFLAGS: -I./
 #cgo LDFLAGS: -L. -lchdb
 #include "chdb.h"
@@ -9,20 +8,20 @@ package chdb
 #include <stdio.h>
 #include <stdlib.h>
 
-char *MyResult(char *query, char *format) {
+char *Execute(char *query, char *format) {
 
     char * argv[] = {(char *)"clickhouse", (char *)"--multiquery", (char *)"--output-format=CSV", (char *)"--query="};
     char dataFormat[100]; 
     char *localQuery;
-    //Total 4 = 3 arguments + 1 programm name
+    // Total 4 = 3 arguments + 1 programm name
     int argc = 4;
-    struct local_result *myresult;    
+    struct local_result *result;    
 
-    //Format
+    // Format
     snprintf(dataFormat, sizeof(dataFormat), "--format=%s", format);
     argv[2]=strdup(dataFormat);
 
-    //Query - 10 characters + length of query
+    // Query - 10 characters + length of query
     localQuery = (char *) malloc(strlen(query)+10);
     if(localQuery == NULL) {
     
@@ -34,14 +33,14 @@ char *MyResult(char *query, char *format) {
     argv[3]=strdup(localQuery);
     free(localQuery);
 
-    //Main query and result
-    myresult = query_stable(argc, argv);
+    // Main query and result
+    result = query_stable(argc, argv);
 
     //Free it
     free(argv[2]);
     free(argv[3]);
 
-    return myresult->buf;
+    return result->buf;
 }
 */
 import "C"
@@ -52,6 +51,6 @@ func Query(str1, str2 string) string {
     defer C.free(unsafe.Pointer(query))
     format := C.CString(str2)
     defer C.free(unsafe.Pointer(format))
-    resultData := C.MyResult(query, format)
+    resultData := C.Execute(query, format)
     return C.GoString(resultData)
 }

--- a/chdb/go.mod
+++ b/chdb/go.mod
@@ -1,3 +1,3 @@
-module chdb
+module https://github.com/chdb-io/chdb-go/chdb
 
 go 1.18

--- a/chdb/go.mod
+++ b/chdb/go.mod
@@ -1,3 +1,3 @@
-module https://github.com/chdb-io/chdb-go/chdb
+module github.com/chdb-io/chdb-go/chdb
 
 go 1.18

--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
     "fmt"
-    "chdb"
     "flag"
+    "github.com/chdb-io/chdb-go/chdb"
 )
 
 func main() {


### PR DESCRIPTION
- Rename module to `github.com/chdb-io/chdb-go/chdb`
- Remove python bindings and build dependencies
- Switch action use to experimental libchdb.so builds